### PR TITLE
Add a settings file with comment format

### DIFF
--- a/settings/language-gams.cson
+++ b/settings/language-gams.cson
@@ -1,0 +1,3 @@
+".source.gams":
+  editor:
+    commentStart: "* "


### PR DESCRIPTION
This lets you do `ctrl+/` to toggle comments on more than one line, e.g. 

```cobol
Equations
equation1
equation2
equation3
;
```
CTRL+/

```cobol
* Equations
* equation1
* equation2
* equation3
* ;
```