### PR TITLE
Syntax highlighting for embedded python code

### DIFF
--- a/grammars/gams.cson
+++ b/grammars/gams.cson
@@ -212,8 +212,8 @@
     'name': 'support.utility.gams'
   }
   {
-    'begin': '\\b(?i)(onembeddedcode)\\b'
-    'end': '\\b(?i)(offembeddedcode)\\b'
+    'begin': '\\b(?i)(onembeddedcode|onembeddedcodes|onembeddedcodev|continueembeddedcode|embeddedcode|embeddedcodes|embeddedcodev)\\b'
+    'end': '\\b(?i)(offembeddedcode|pauseembeddedcode|endembeddedcode)\\b'
     'name': 'keyword.control.embedded.gams'
     'patterns': [
       {

--- a/grammars/gams.cson
+++ b/grammars/gams.cson
@@ -50,8 +50,7 @@
   }
   {
     'match': '\\(|\\)'
-    'name': 'keyword.ope
-rator.parenthesis.gams'
+    'name': 'keyword.operator.parenthesis.gams'
   }
   {
     'match': ','
@@ -211,5 +210,15 @@ rator.parenthesis.gams'
   {
     'match': '\\b(?i)(csv2gdx|gdx(copy|diff|dump|merge|rank|viewer|xrw|2access|2xls)|mcfilter|mdb2gms|sql2gms|xls2gms)\\b'
     'name': 'support.utility.gams'
+  }
+  {
+    'begin': '\\b(?i)(onembeddedcode)\\b'
+    'end': '\\b(?i)(offembeddedcode)\\b'
+    'name': 'keyword.control.embedded.gams'
+    'patterns': [
+      {
+        'include': 'source.python'
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Adds syntax highlighting for the [embedded code facility](https://www.gams.com/latest/docs/UG_EmbeddedCode.html) 
![image](https://user-images.githubusercontent.com/20703207/57631013-f956ab00-759e-11e9-89fd-09ed6b6b9a5e.png)
